### PR TITLE
Add environment variables for opsman and pivnet token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # pivomatic
-Bash Script to wrap around Pivnet CLI and OM. This script downloads and uploads with a single command. Intended to be used on a Jump Server for easy internet access. 
+Bash Script to wrap around Pivnet CLI and OM. This script downloads and uploads with a single command. Intended to be used on a Jump Server for easy internet access.
 Note: Sometimes the Pivnet Api (network.pivotal.io) returns multiple files marked as software, in this case the process is stopped and the id needs to be provided with a flag.
 
+Pivomatic uses default [om](https://github.com/pivotal-cf/om) environment variables and you can use the same in `pivomatic` as suggested by the usage below.
+
 ```bash
-Usage: pivomatic 
-        -t <pivnet-token> 
-        -o <opsman-url> 
-        -u <opsman-user> 
-        -p <opsman-pass> 
-        -s <product-slug> 
+Usage: pivomatic
+        -t <pivnet-token>, PIVNET_TOKEN
+        -o <opsman-url>, OM_TARGET
+        -u <opsman-user>, OM_USERNAME
+        -p <opsman-pass>, OM_PASSWORD
+        -s <product-slug>
         -r <release>
         -i <id (optional)>
 ```
@@ -27,4 +29,4 @@ After upload it will provide you with a summary of uploaded products on OpsManag
 
 ### Why BASH? No GOLANG?
 
-Was on the go while writing this and only had my iPad with me with access to that Jump Box. Served me well and will do the same for you. 
+Was on the go while writing this and only had my iPad with me with access to that Jump Box. Served me well and will do the same for you.

--- a/pivomatic
+++ b/pivomatic
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-usage() { 
-  echo -e "Usage: 
-  $0 
-  -t <pivnet-token> 
-  -o <opsman-url> 
-  -u <opsman-user> 
-  -p <opsman-pass> 
-  -s <product-slug> 
+usage() {
+  echo -e "Usage:
+  $0
+  -t <pivnet-token>, PIVNET_TOKEN
+  -o <opsman-url>, OM_TARGET
+  -u <opsman-user>, OM_USERNAME
+  -p <opsman-pass>, OM_PASSWORD
+  -s <product-slug>
   -r <release>
   -i <id (optional)> \n" >&2; exit 1; }
 
@@ -45,7 +45,7 @@ summary() {
 download-pivnet() {
   JSON=`pivnet product-files -p $SLUG -r $RELEASE --format=json`
 
-  if [ -z "$PRODUCTID" ]; then 
+  if [ -z "$PRODUCTID" ]; then
     PRODUCTID=$(echo $JSON | jq '.[] | select(.file_type =="Software").id')
 
     if [[ $PRODUCTID = *[[:space:]]* ]]; then
@@ -61,7 +61,7 @@ download-pivnet() {
   pivnet download-product-files -p $SLUG -r $RELEASE -i $PRODUCTID --accept-eula
 
   AWS_OBJECT_KEY=$(echo $JSON | jq ".[] | select(.file_type ==\"Software\" and .id == ${PRODUCTID}).aws_object_key")
-  
+
   OBJECT_KEY=${AWS_OBJECT_KEY##*/}
   STRIPPED_OBJECT_KEY=${OBJECT_KEY%.*}
 }
@@ -99,6 +99,12 @@ while getopts ":t:o:u:p:s:r:i:h" opt; do
   esac
 done
 
+# subtitutes with variable env if parameters are not defined
+
+TOKEN=${TOKEN:-$PIVNET_TOKEN}
+OPSMAN=${OPSMAN:-$OM_TARGET}
+USER=${USER:-$OM_USERNAME}
+PASSWD=${PASSWD:-$OM_PASSWORD}
 
 checkcmds
 login

--- a/pivomatic
+++ b/pivomatic
@@ -31,15 +31,15 @@ checkcmds () {
 }
 
 login (){
-  pivnet login --api-token="${TOKEN}"
+  pivnet login --api-token="${PIVNET_TOKEN}"
 }
 
 om-upload () {
-  om-linux -target $OPSMAN --skip-ssl-validation -u "${USER}" -p "${PASSWD}" upload-product --product "${STRIPPED_OBJECT_KEY}".pivotal
+  om-linux -target $OM_TARGET --skip-ssl-validation -u "${OM_USERNAME}" -p "${OM_PASSWORD}" upload-product --product "${STRIPPED_OBJECT_KEY}".pivotal
 }
 
 summary() {
-  om-linux  -target $OPSMAN --skip-ssl-validation -u "${USER}" -p "${PASSWD}" available-products
+  om-linux  -target $OM_TARGET --skip-ssl-validation -u "${OM_USERNAME}" -p "${OM_PASSWORD}" available-products
 }
 
 download-pivnet() {
@@ -73,13 +73,13 @@ fi
 
 while getopts ":t:o:u:p:s:r:i:h" opt; do
   case $opt in
-    t) TOKEN=$OPTARG
+    t) PIVNET_TOKEN=$OPTARG
       ;;
-    o) OPSMAN=$OPTARG
+    o) OM_TARGET=$OPTARG
       ;;
-    u) USER=$OPTARG
+    u) OM_USERNAME=$OPTARG
       ;;
-    p) PASSWD=$OPTARG
+    p) OM_PASSWORD=$OPTARG
       ;;
     s) SLUG=$OPTARG
       ;;
@@ -98,13 +98,6 @@ while getopts ":t:o:u:p:s:r:i:h" opt; do
       ;;
   esac
 done
-
-# subtitutes with variable env if parameters are not defined
-
-TOKEN=${TOKEN:-$PIVNET_TOKEN}
-OPSMAN=${OPSMAN:-$OM_TARGET}
-USER=${USER:-$OM_USERNAME}
-PASSWD=${PASSWD:-$OM_PASSWORD}
 
 checkcmds
 login


### PR DESCRIPTION
Hello,

I've added code so that, if some parameters are not set, it will try to use env var instead.
I've used the same variables used by tool [om](https://github.com/pivotal-cf/om) so that they're only need to set up once for `pivomatic` and `om`.

To avoid more lines, I could have renamed the variables in `pivomatic` to the environment variables used, so, if not set, they would use environment variables (without extra coding lines), but it might become verbose as env var are longer. Don't know what's the best to implement. I'd be happy to change if needed 😄